### PR TITLE
feat(api): implement Flux interceptor API 

### DIFF
--- a/src/api/flux.ts
+++ b/src/api/flux.ts
@@ -1,0 +1,58 @@
+// shelter-mod inspired
+import type { FluxDispatcher as FD } from "discord-types/other";
+
+type FluxDispatcherWithInterceptors = FD & {
+    _interceptors: FluxIntercept[];
+};
+
+const blockedSym = Symbol.for("wintry.flux.blocked");
+const modifiedSym = Symbol.for("wintry.flux.modified");
+
+export type FluxEvent = Record<string, any> & { type: string };
+export type FluxIntercept = (payload: FluxEvent) => any;
+let intercepts: FluxIntercept[] = [];
+
+/**
+ * @internal
+ * Injects a Flux interceptor into the dispatcher. This will be called in FluxAPI plugin.
+ * It returns a function to remove the interceptor.
+ */
+export function injectFluxInterceptor(FluxDispatcher: FluxDispatcherWithInterceptors) {
+    const cb = (payload: any) => {
+        let blocked = false;
+        let modified = false;
+
+        for (let i = 0, len = intercepts.length; i < len; i++) {
+            const res = intercepts[i](payload);
+
+            if (res == null) continue;
+
+            if (!res) {
+                blocked = true;
+            } else if (typeof res === "object") {
+                Object.assign(payload, res);
+                modified = true;
+            }
+        }
+
+        if (blocked) payload[blockedSym] = true;
+        if (modified) payload[modifiedSym] = true;
+
+        return blocked;
+    };
+
+    (FluxDispatcher._interceptors ??= []).unshift(cb);
+    return () => FluxDispatcher._interceptors.filter(v => v !== cb);
+}
+
+/**
+ * Intercept Flux dispatches. Return type affects the end result, where
+ * nullish -> nothing, falsy -> block, object -> modify
+ */
+export function interceptFluxEvent(cb: FluxIntercept) {
+    intercepts.push(cb);
+
+    return () => {
+        intercepts = intercepts.filter(i => i !== cb);
+    };
+}

--- a/src/api/flux.ts
+++ b/src/api/flux.ts
@@ -42,7 +42,9 @@ export function injectFluxInterceptor(FluxDispatcher: FluxDispatcherWithIntercep
     };
 
     (FluxDispatcher._interceptors ??= []).unshift(cb);
-    return () => FluxDispatcher._interceptors.filter(v => v !== cb);
+    return () => {
+        FluxDispatcher._interceptors = FluxDispatcher._interceptors.filter(v => v !== cb);
+    };
 }
 
 /**

--- a/src/api/flux.ts
+++ b/src/api/flux.ts
@@ -1,4 +1,3 @@
-// shelter-mod inspired
 import type { FluxDispatcher as FD } from "discord-types/other";
 
 type FluxDispatcherWithInterceptors = FD & {
@@ -8,9 +7,11 @@ type FluxDispatcherWithInterceptors = FD & {
 const blockedSym = Symbol.for("wintry.flux.blocked");
 const modifiedSym = Symbol.for("wintry.flux.modified");
 
-export type FluxEvent = Record<string, any> & { type: string };
-export type FluxIntercept = (payload: FluxEvent) => any;
 let intercepts: FluxIntercept[] = [];
+const typeSpecificIntercepts: Map<string, FluxIntercept[]> = new Map();
+
+export type FluxEvent = Record<string, any> & { type: string, [blockedSym]?: boolean, [modifiedSym]?: boolean };
+export type FluxIntercept = (payload: FluxEvent) => any;
 
 /**
  * @internal
@@ -18,10 +19,11 @@ let intercepts: FluxIntercept[] = [];
  * It returns a function to remove the interceptor.
  */
 export function injectFluxInterceptor(FluxDispatcher: FluxDispatcherWithInterceptors) {
-    const cb = (payload: any) => {
+    const cb = (payload: FluxEvent) => {
         let blocked = false;
         let modified = false;
 
+        // Process general interceptors
         for (let i = 0, len = intercepts.length; i < len; i++) {
             const res = intercepts[i](payload);
 
@@ -32,6 +34,23 @@ export function injectFluxInterceptor(FluxDispatcher: FluxDispatcherWithIntercep
             } else if (typeof res === "object") {
                 Object.assign(payload, res);
                 modified = true;
+            }
+        }
+
+        // Process type-specific interceptors
+        const typeSpecific = typeSpecificIntercepts.get(payload.type);
+        if (typeSpecific) {
+            for (let i = 0, len = typeSpecific.length; i < len; i++) {
+                const res = typeSpecific[i](payload);
+
+                if (res == null) continue;
+
+                if (!res) {
+                    blocked = true;
+                } else if (typeof res === "object") {
+                    Object.assign(payload, res);
+                    modified = true;
+                }
             }
         }
 
@@ -56,5 +75,31 @@ export function interceptFluxEvent(cb: FluxIntercept) {
 
     return () => {
         intercepts = intercepts.filter(i => i !== cb);
+    };
+}
+
+/**
+ * Intercept Flux dispatches for a specific event type. This is more performant
+ * than the general interceptor when you only need to listen to specific events.
+ * Return type affects the end result, where nullish -> nothing, falsy -> block, object -> modify
+ */
+export function interceptFluxEventType(eventType: string, cb: FluxIntercept) {
+    const existing = typeSpecificIntercepts.get(eventType);
+    if (existing) {
+        existing.push(cb);
+    } else {
+        typeSpecificIntercepts.set(eventType, [cb]);
+    }
+
+    return () => {
+        const callbacks = typeSpecificIntercepts.get(eventType);
+        if (callbacks) {
+            const filtered = callbacks.filter(i => i !== cb);
+            if (filtered.length === 0) {
+                typeSpecificIntercepts.delete(eventType);
+            } else {
+                typeSpecificIntercepts.set(eventType, filtered);
+            }
+        }
     };
 }

--- a/src/api/flux.ts
+++ b/src/api/flux.ts
@@ -11,6 +11,11 @@ let intercepts: FluxIntercept[] = [];
 const typeSpecificIntercepts: Map<string, FluxIntercept[]> = new Map();
 
 export type FluxEvent = Record<string, any> & { type: string, [blockedSym]?: boolean, [modifiedSym]?: boolean };
+
+/**
+ * Function type for intercepting Flux events.
+ * Return value determines behavior: null/undefined = pass through, false = block, object = modify.
+ */
 export type FluxIntercept = (payload: FluxEvent) => any;
 
 /**
@@ -67,8 +72,32 @@ export function injectFluxInterceptor(FluxDispatcher: FluxDispatcherWithIntercep
 }
 
 /**
- * Intercept Flux dispatches. Return type affects the end result, where
- * nullish -> nothing, falsy -> block, object -> modify
+ * Intercept ALL Flux events globally. Use `interceptFluxEventType()` for better performance
+ * when targeting specific event types.
+ * 
+ * @param cb - Interceptor function. Return values:
+ *   - `null`/`undefined`: Pass through unchanged
+ *   - `false` or falsy: Block the event  
+ *   - Object: Modify by merging with original payload
+ * @returns Cleanup function to remove the interceptor
+ * 
+ * @example
+ * ```ts
+ * // Global event logger
+ * const cleanup = interceptFluxEvent((payload) => {
+ *     console.log(`Event: ${payload.type}`, payload);
+ *     return null; // Don't modify
+ * });
+ * 
+ * // Block all message events
+ * const blockMessages = interceptFluxEvent((payload) => {
+ *     return payload.type.startsWith("MESSAGE_") ? false : null;
+ * });
+ * 
+ * // Clean up
+ * cleanup();
+ * blockMessages();
+ * ```
  */
 export function interceptFluxEvent(cb: FluxIntercept) {
     intercepts.push(cb);
@@ -79,9 +108,44 @@ export function interceptFluxEvent(cb: FluxIntercept) {
 }
 
 /**
- * Intercept Flux dispatches for a specific event type. This is more performant
- * than the general interceptor when you only need to listen to specific events.
- * Return type affects the end result, where nullish -> nothing, falsy -> block, object -> modify
+ * Intercept Flux events for a specific event type.
+ * 
+ * @param eventType - Event type to intercept (e.g., "MESSAGE_CREATE", "TYPING_START")
+ * @param cb - Interceptor function. Return values:
+ *   - `null`/`undefined`: Pass through unchanged
+ *   - `false` or falsy: Block the event
+ *   - Object: Modify by merging with original payload
+ * @returns Cleanup function to remove the interceptor
+ * 
+ * @example
+ * ```ts
+ * // Block messages with bad words
+ * const censor = interceptFluxEventType("MESSAGE_CREATE", (payload) => {
+ *     if (payload.content?.includes("badword")) {
+ *         return false; // Block completely
+ *     }
+ *     return null;
+ * });
+ * 
+ * // Replace words in messages
+ * const replace = interceptFluxEventType("MESSAGE_CREATE", (payload) => {
+ *     if (payload.content?.includes("old")) {
+ *         return { content: payload.content.replace("old", "new") };
+ *     }
+ *     return null;
+ * });
+ * 
+ * // Log typing events
+ * const logTyping = interceptFluxEventType("TYPING_START", (payload) => {
+ *     console.log(`${payload.userId} typing in ${payload.channelId}`);
+ *     return null;
+ * });
+ * 
+ * // Cleanup
+ * censor();
+ * replace();
+ * logTyping();
+ * ```
  */
 export function interceptFluxEventType(eventType: string, cb: FluxIntercept) {
     const existing = typeSpecificIntercepts.get(eventType);

--- a/src/metro/lazy.ts
+++ b/src/metro/lazy.ts
@@ -8,10 +8,6 @@ export class LazyModuleContext<A = unknown, R = unknown, O = unknown> {
     static ProxySymbol = Symbol.for("wintry.metro.lazyContext");
     static ProxyMap = new WeakMap<any, LazyModuleContext<any, any, any>>();
 
-    static getContext(object: any): LazyModuleContext<any, any, any> | undefined {
-        return LazyModuleContext.ProxyMap.get(object) ?? object[LazyModuleContext.ProxySymbol];
-    }
-
     private _proxy: R | undefined;
 
     filter: ModuleFilter<A, R, O>;

--- a/src/metro/lazy.ts
+++ b/src/metro/lazy.ts
@@ -8,6 +8,10 @@ export class LazyModuleContext<A = unknown, R = unknown, O = unknown> {
     static ProxySymbol = Symbol.for("wintry.metro.lazyContext");
     static ProxyMap = new WeakMap<any, LazyModuleContext<any, any, any>>();
 
+    static getContext(object: any): LazyModuleContext<any, any, any> | undefined {
+        return LazyModuleContext.ProxyMap.get(object) ?? object[LazyModuleContext.ProxySymbol];
+    }
+
     private _proxy: R | undefined;
 
     filter: ModuleFilter<A, R, O>;

--- a/src/plugins/_api/flux/index.tsx
+++ b/src/plugins/_api/flux/index.tsx
@@ -1,0 +1,23 @@
+import { definePlugin } from "#plugin-context";
+import { injectFluxInterceptor } from "@api/flux";
+import { Devs } from "@data/constants";
+import { byProps } from "@metro/common/filters";
+
+export default definePlugin({
+    name: "FluxAPI",
+    description: "Provides an API for intercepting Flux dispatches.",
+    authors: [Devs.Pylix],
+
+    required: true,
+
+    patches: [
+        {
+            id: "intercept-flux-dispatcher",
+            target: byProps(["_interceptors"]),
+            patch(module, patcher) {
+                const uninject = injectFluxInterceptor(module);
+                patcher.attachDisposer(() => void uninject());
+            },
+        },
+    ],
+});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -4,6 +4,7 @@ import type usePluginStore from "@stores/usePluginStore";
 import type { Filter } from "@metro/common/filters";
 import type { ContextualPatcher } from "@patcher/contextual";
 import type { WithThis } from "@utils/types";
+import type { FluxIntercept } from "@api/flux";
 
 export interface PluginState {
     running: boolean;
@@ -49,6 +50,8 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
     readonly isAvailable?: () => boolean;
 
     readonly patches?: PluginPatch[];
+
+    readonly flux?: Record<string, FluxIntercept>;
 
     /**
      * This is called once the index module is loaded and you can force lookup modules from here.

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -51,6 +51,22 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
 
     readonly patches?: PluginPatch[];
 
+    /**
+     * Define Flux event interceptors for specific event types. Allows intercepting,
+     * modifying, or blocking Discord's Flux events.
+     * 
+     * Each key is a Flux event type, and each value is a FluxIntercept function.
+     * @example
+     * ```ts
+     * flux: {
+     *     "MESSAGE_CREATE": (payload) => {
+     *         if (payload.content.includes("spam")) {
+     *             return false; // Block spam messages
+     *         }
+     *         return null; // Let other messages pass through
+     *     },
+     * }
+     */
     readonly flux?: Record<string, FluxIntercept>;
 
     /**

--- a/src/stores/usePluginStore.ts
+++ b/src/stores/usePluginStore.ts
@@ -85,7 +85,7 @@ function applyPluginFluxInterceptors(
 
         pluginPatcherContext.attachDisposer(() => {
             unintercept();
-            logger.debug(`Intercepted from flux event '${eventName}' for plugin '${id}'`);
+            logger.debug(`Unintercepted from flux event '${eventName}' for plugin '${id}'`);
         });
     }
 }

--- a/src/stores/usePluginStore.ts
+++ b/src/stores/usePluginStore.ts
@@ -8,7 +8,7 @@ import { wtlogger } from "@api/logger";
 import { isSafeModeEnabled } from "@loader";
 import { waitFor } from "@metro/internal/modules";
 import { getContextualPatcher, getPluginSettings } from "@plugins/utils";
-import { interceptFluxEvent, type FluxEvent } from "@api/flux";
+import { interceptFluxEventType, type FluxEvent } from "@api/flux";
 import type { ContextualPatcher } from "@patcher/contextual";
 
 const logger = wtlogger.createChild("PluginStore");
@@ -72,9 +72,8 @@ function applyPluginFluxInterceptors(
     if (!plugin.flux) return;
 
     for (const [eventName, cb] of Object.entries(plugin.flux)) {
-        const unintercept = interceptFluxEvent((event: FluxEvent) => {
+        const unintercept = interceptFluxEventType(eventName, (event: FluxEvent) => {
             try {
-                if (event.type !== eventName) return;
                 return cb(event);
             } catch (e) {
                 logger.error`${id}: Error while handling ${event.type}: ${e}`;


### PR DESCRIPTION
## What's new

* Added `api/flux`, a utility for intercepting Flux dispatches. You can block, modify, or let events pass through.
* Introduced a `FluxAPI` plugin that wires up the interception logic.
* Plugin system changes:
  * Plugins can now define a `flux` property to handle specific events.
  * Interceptors are properly cleaned up when the plugin stops.
  * Patch context handling is now a bit more robust.

## Example

Silent typing, for example:

```ts
export default definePlugin({
    name: "SilentTyping",
    // ...
    flux: {
        TYPING_START_LOCAL: () => {
            if (settings.get().silentTypingActive) return false; // block it
        },
    },
});
```

---

## Status

This is a draft until we confirm whether it's possible to hook into specific Flux events. There's a good chance Discord/Facebook does expose something useful, but it needs proper research.

Right now, interception looks like this:

```ts
interceptFluxEvent((event) => {
    if (event.type !== "TYPING_START") return;
    // handle the event
});
```

Would be better if we didn't have to manually filter every event, but until we know what's actually possible, this does raise performance concerns since every single dispatched event goes through the interceptor.