### PR TITLE
feat(commands): Implement commands API

### DIFF
--- a/src/api/commands/helpers.ts
+++ b/src/api/commands/helpers.ts
@@ -2,7 +2,7 @@ import { Clyde, MessageActions } from "@metro/common/libraries";
 import type { Message } from "discord-types/general";
 import { toMerged } from "es-toolkit";
 import type { PartialDeep } from "type-fest";
-import type { CommandOption, WintryApplicationCommand } from "./types";
+import type { CommandOption, WintryApplicationCommandDefinition } from "./types";
 
 export function replyCommand(channelId: string, message: PartialDeep<Message>, ephemeral = true): Message {
     if (ephemeral) {
@@ -32,7 +32,7 @@ export function sendBotMessage(channelId: string, message: PartialDeep<Message>)
  * @param command The command to define.
  */
 export function defineCommand<const CO extends readonly CommandOption[]>(
-    command: WintryApplicationCommand<CO> & { id?: never },
-): WintryApplicationCommand<CommandOption[]> & { id?: never } {
-    return command as unknown as WintryApplicationCommand<CommandOption[]> & { id?: never };
+    command: WintryApplicationCommandDefinition<CO>,
+): WintryApplicationCommandDefinition<CommandOption[]> {
+    return command as unknown as WintryApplicationCommandDefinition<CommandOption[]>;
 }

--- a/src/api/commands/helpers.ts
+++ b/src/api/commands/helpers.ts
@@ -4,19 +4,25 @@ import { toMerged } from "es-toolkit";
 import type { PartialDeep } from "type-fest";
 import type { CommandOption, WintryApplicationCommandDefinition } from "./types";
 
-export function replyCommand(channelId: string, message: PartialDeep<Message>, ephemeral = true): Message {
+/**
+ * Sends a reply message to a specified channel, with optional ephemeral behavior.
+ *
+ * @param channelId - The ID of the channel to send the message to.
+ * @param message - The message content to send, as a partial deep structure of the Message type.
+ * @param ephemeral - If true, sends the message as an ephemeral (temporary) bot message. Defaults to true.
+ */
+export function replyCommand(channelId: string, message: PartialDeep<Message>, ephemeral = true) {
     if (ephemeral) {
-        return sendBotMessage(channelId, message);
+        sendBotMessage(channelId, message);
     }
 
-    return MessageActions.sendMessage(channelId, message);
+    MessageActions.sendMessage(channelId, message);
 }
 
 /**
  * Send a message as Clyde
- * @param {string} channelId ID of channel to send message to
- * @param {Message} message Message to send
- * @returns {Message}
+ * @param channelId - ID of channel to send message to
+ * @param message - Message to send
  */
 export function sendBotMessage(channelId: string, message: PartialDeep<Message>): Message {
     const botMessage = Clyde.createBotMessage({ channelId, content: "", embeds: [] });

--- a/src/api/commands/helpers.ts
+++ b/src/api/commands/helpers.ts
@@ -31,9 +31,8 @@ export function sendBotMessage(channelId: string, message: PartialDeep<Message>)
  * To register a command, use `registerCommand` instead.
  * @param command The command to define.
  */
-
 export function defineCommand<const CO extends readonly CommandOption[]>(
     command: WintryApplicationCommand<CO> & { id?: never },
-): WintryApplicationCommand<CommandOption[]> {
-    return command as unknown as WintryApplicationCommand<CommandOption[]>;
+): WintryApplicationCommand<CommandOption[]> & { id?: never } {
+    return command as unknown as WintryApplicationCommand<CommandOption[]> & { id?: never };
 }

--- a/src/api/commands/helpers.ts
+++ b/src/api/commands/helpers.ts
@@ -2,6 +2,7 @@ import { Clyde, MessageActions } from "@metro/common/libraries";
 import type { Message } from "discord-types/general";
 import { toMerged } from "es-toolkit";
 import type { PartialDeep } from "type-fest";
+import type { CommandOption, WintryApplicationCommand } from "./types";
 
 export function replyCommand(channelId: string, message: PartialDeep<Message>, ephemeral = true): Message {
     if (ephemeral) {
@@ -23,4 +24,16 @@ export function sendBotMessage(channelId: string, message: PartialDeep<Message>)
     MessageActions.receiveMessage(channelId, toMerged(botMessage, message));
 
     return message as Message;
+}
+
+/**
+ * Only exists for type safety, does not actually do anything. Only returns the command as is.
+ * To register a command, use `registerCommand` instead.
+ * @param command The command to define.
+ */
+
+export function defineCommand<const CO extends readonly CommandOption[]>(
+    command: WintryApplicationCommand<CO> & { id?: never },
+): WintryApplicationCommand<CommandOption[]> {
+    return command as unknown as WintryApplicationCommand<CommandOption[]>;
 }

--- a/src/api/commands/helpers.ts
+++ b/src/api/commands/helpers.ts
@@ -1,0 +1,26 @@
+import { Clyde, MessageActions } from "@metro/common/libraries";
+import type { Message } from "discord-types/general";
+import { toMerged } from "es-toolkit";
+import type { PartialDeep } from "type-fest";
+
+export function replyCommand(channelId: string, message: PartialDeep<Message>, ephemeral = true): Message {
+    if (ephemeral) {
+        return sendBotMessage(channelId, message);
+    }
+
+    return MessageActions.sendMessage(channelId, message);
+}
+
+/**
+ * Send a message as Clyde
+ * @param {string} channelId ID of channel to send message to
+ * @param {Message} message Message to send
+ * @returns {Message}
+ */
+export function sendBotMessage(channelId: string, message: PartialDeep<Message>): Message {
+    const botMessage = Clyde.createBotMessage({ channelId, content: "", embeds: [] });
+
+    MessageActions.receiveMessage(channelId, toMerged(botMessage, message));
+
+    return message as Message;
+}

--- a/src/api/commands/index.ts
+++ b/src/api/commands/index.ts
@@ -1,7 +1,11 @@
 import { after } from "@patcher";
 import { ApplicationCommandInputType, ApplicationCommandType } from "./types";
-import type { ApplicationCommand, CommandOption, WintryApplicationCommand } from "./types";
-import type { Mutable } from "@utils/types";
+import type {
+    ApplicationCommand,
+    CommandOption,
+    WintryApplicationCommand,
+    WintryApplicationCommandDefinition,
+} from "./types";
 
 let registeredCommands: WintryApplicationCommand<readonly CommandOption[]>[] = [];
 const commandIdSet = new Set<string>();
@@ -36,7 +40,7 @@ export function patchCommands(commandsModule: any) {
 }
 
 export function registerCommand<const CO extends readonly CommandOption[]>(
-    command: Mutable<WintryApplicationCommand<CO> & { id?: never }>,
+    command: WintryApplicationCommandDefinition<CO>,
 ): () => void {
     command.applicationId ??= "-1";
     command.type ??= ApplicationCommandType.CHAT;
@@ -46,9 +50,13 @@ export function registerCommand<const CO extends readonly CommandOption[]>(
     command.displayDescription ??= command.description;
     command.untranslatedDescription ??= command.description;
 
+    // @ts-ignore: This is a custom property for Wintry commands
     command.__WINTRY_EXTRA = {
         shouldHide: command.shouldHide,
     };
+
+    // @ts-ignore: Remove all properties that are not part of the WintryCommand type
+    command.shouldHide = undefined;
 
     if (command.options) {
         for (const opt of command.options) {

--- a/src/api/commands/index.ts
+++ b/src/api/commands/index.ts
@@ -17,7 +17,7 @@ const commandIdSet = new Set<string>();
 export function patchCommands(commandsModule: any) {
     const unpatch = after(commandsModule, "getBuiltInCommands", ([type]: any[], res: ApplicationCommand<any>[]) => {
         const commandsToInclude = registeredCommands.filter(
-            c => type.includes(c.type) && c.__WINTRY_EXTRA?.wt_predicate?.() !== false,
+            c => type.includes(c.type) && c.__WINTRY_EXTRA?.wtPredicate?.() !== false,
         );
 
         // Assign IDs to commands that need them
@@ -51,7 +51,7 @@ export function registerCommand<const CO extends readonly CommandOption[]>(
     command.untranslatedDescription ??= command.description;
 
     for (const key of Object.keys(command)) {
-        if (key.startsWith("wt_")) {
+        if (key.startsWith("wt")) {
             // Ensure that any custom properties are not included in the final command object
             // This is to prevent issues with Discord's command registration
             const cmm = command as any;

--- a/src/api/commands/index.ts
+++ b/src/api/commands/index.ts
@@ -15,9 +15,7 @@ let registeredCommands: WintryApplicationCommand<readonly CommandOption[]>[] = [
  */
 export function patchCommands(commandsModule: any) {
     const unpatch = after(commandsModule, "getBuiltInCommands", ([type]: any[], res: ApplicationCommand<any>[]) => {
-        const commandsToInclude = registeredCommands.filter(
-            c => type.includes(c.type) && c.__WINTRY_EXTRA?.wtPredicate?.() !== false,
-        );
+        const commandsToInclude = registeredCommands.filter(c => type.includes(c.type) && c.wtPredicate?.() !== false);
 
         // Assign IDs to commands that need them
         for (const command of commandsToInclude) {
@@ -46,17 +44,6 @@ export function registerCommand<const CO extends readonly CommandOption[]>(
     command.untranslatedName ??= command.name;
     command.displayDescription ??= command.description;
     command.untranslatedDescription ??= command.description;
-
-    for (const key of Object.keys(command)) {
-        if (key.startsWith("wt")) {
-            // Ensure that any custom properties are not included in the final command object
-            // This is to prevent issues with Discord's command registration
-            const cmm = command as any;
-            delete cmm[key];
-            cmm.__WINTRY_EXTRA ??= {};
-            cmm.__WINTRY_EXTRA[key] = cmm[key];
-        }
-    }
 
     if (command.options) {
         for (const opt of command.options) {

--- a/src/api/commands/index.ts
+++ b/src/api/commands/index.ts
@@ -1,0 +1,94 @@
+import { after } from "@patcher";
+import { wtlogger } from "@api/logger";
+import { ApplicationCommandInputType, ApplicationCommandType } from "./types";
+import type { ApplicationCommand, WintryApplicationCommand } from "./types";
+
+let registeredCommands: ApplicationCommand[] = [];
+const commandIdSet = new Set<string>();
+
+/**
+ * Patches the commands module to include Wintry's custom commands.
+ * @internal
+ */
+export function patchCommands(commandsModule: any) {
+    const unpatch = after(commandsModule, "getBuiltInCommands", ([type]: any[], res: ApplicationCommand[]) => {
+        const commandsToInclude = registeredCommands.filter(
+            c => type.includes(c.type) && c.__WINTRY_INTERNALS?.shouldHide?.() !== true,
+        );
+
+        // Assign IDs to commands that need them
+        for (const command of commandsToInclude) {
+            if (!command.id) {
+                command.id = generateCommandId([...res, ...commandsToInclude.filter(c => c.id)]);
+                commandIdSet.add(command.id);
+            }
+        }
+
+        return [...res, ...commandsToInclude];
+    });
+
+    return () => {
+        registeredCommands = [];
+        commandIdSet.clear();
+        unpatch();
+    };
+}
+
+export function registerCommand(command: Omit<WintryApplicationCommand, "id">): () => void {
+    command.applicationId ??= "-1";
+    command.type ??= ApplicationCommandType.CHAT;
+    command.inputType = ApplicationCommandInputType.BUILT_IN;
+    command.displayName ??= command.name;
+    command.untranslatedName ??= command.name;
+    command.displayDescription ??= command.description;
+    command.untranslatedDescription ??= command.description;
+
+    command.__WINTRY_INTERNALS = {
+        shouldHide: command.shouldHide,
+    };
+
+    if (command.options) {
+        for (const opt of command.options) {
+            opt.displayName ??= opt.name;
+            opt.displayDescription ??= opt.description;
+        }
+    }
+
+    // Add it to the commands array (ID will be assigned when getBuiltInCommands is called)
+    registeredCommands.push(command);
+    wtlogger.debug`Registered command: ${command.name}`;
+
+    return () => {
+        registeredCommands = registeredCommands.filter(c => c !== command);
+
+        // @ts-expect-error - command.id can exist in here
+        if (command.id) commandIdSet.delete(command.id);
+
+        wtlogger.debug`Deregistered command: ${command.name}`;
+    };
+}
+
+/**
+ * Generate a unique command ID that doesn't conflict with existing commands
+ */
+function generateCommandId(currCommands: ApplicationCommand[]): string {
+    let baseId = -100;
+
+    if (currCommands.length > 0) {
+        const sortedCommands = currCommands.sort((a, b) => Number.parseInt(b.id!) - Number.parseInt(a.id!));
+        const lastCommand = sortedCommands[sortedCommands.length - 1];
+        if (lastCommand?.id) {
+            const lastId = Number.parseInt(lastCommand.id, 10);
+            if (!Number.isNaN(lastId)) {
+                baseId = Math.min(baseId, lastId - 1);
+            }
+        }
+    }
+
+    // Ensure uniqueness among registered commands
+    while (commandIdSet.has(baseId.toString())) {
+        baseId--;
+    }
+
+    return baseId.toString();
+}

--- a/src/api/commands/index.ts
+++ b/src/api/commands/index.ts
@@ -1,5 +1,4 @@
 import { after } from "@patcher";
-import { wtlogger } from "@api/logger";
 import { ApplicationCommandInputType, ApplicationCommandType } from "./types";
 import type { ApplicationCommand, WintryApplicationCommand } from "./types";
 
@@ -56,15 +55,12 @@ export function registerCommand(command: Omit<WintryApplicationCommand, "id">): 
 
     // Add it to the commands array (ID will be assigned when getBuiltInCommands is called)
     registeredCommands.push(command);
-    wtlogger.debug`Registered command: ${command.name}`;
 
     return () => {
         registeredCommands = registeredCommands.filter(c => c !== command);
 
         // @ts-expect-error - command.id can exist in here
         if (command.id) commandIdSet.delete(command.id);
-
-        wtlogger.debug`Deregistered command: ${command.name}`;
     };
 }
 

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -268,13 +268,10 @@ export interface ApplicationCommand<CO extends readonly CommandOption[]> {
 }
 
 export interface WintryCommandExtra {
-    readonly __WINTRY_EXTRA?: WintryCommandExtra;
     wtPredicate?: () => boolean;
 }
 
 export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryCommandExtra;
 export type WintryApplicationCommandDefinition<CO extends readonly CommandOption[]> = Mutable<
-    Omit<WintryApplicationCommand<CO>, "id"> & {
-        __WINTRY_EXTRA?: never; // This is only used internally
-    }
+    Omit<WintryApplicationCommand<CO>, "id">
 >;

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -257,7 +257,7 @@ export interface ApplicationCommand<CO extends readonly CommandOption[]> {
     readonly description: string;
     readonly execute: (args: MapCommandOptionToArgument<CO>, ctx: CommandContext) => void;
     readonly options: CO;
-    readonly id?: string;
+    readonly id: string;
     readonly applicationId?: string;
     readonly displayName?: string;
     readonly displayDescription?: string;
@@ -274,8 +274,7 @@ export interface WintryCommandExtra {
 
 export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryCommandExtra;
 export type WintryApplicationCommandDefinition<CO extends readonly CommandOption[]> = Mutable<
-    WintryApplicationCommand<CO> & {
-        id?: never; // ID is assigned when the command is registered
+    Omit<WintryApplicationCommand<CO>, "id"> & {
         __WINTRY_EXTRA?: never; // This is only used internally
     }
 >;

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -163,27 +163,42 @@ export interface BooleanArgument extends BaseArgument {
 
 export interface UserArgument extends BaseArgument {
     type: typeof ApplicationCommandOptionType.USER;
-    value: string; // User ID
+    /**
+     * User ID as a string
+     */
+    value: string;
 }
 
 export interface ChannelArgument extends BaseArgument {
     type: typeof ApplicationCommandOptionType.CHANNEL;
-    value: string; // Channel ID
+    /**
+     * Channel ID as a string
+     */
+    value: string;
 }
 
 export interface RoleArgument extends BaseArgument {
     type: typeof ApplicationCommandOptionType.ROLE;
-    value: string; // Role ID
+    /**
+     * Role ID as a string
+     */
+    value: string;
 }
 
 export interface MentionableArgument extends BaseArgument {
     type: typeof ApplicationCommandOptionType.MENTIONABLE;
-    value: string; // User or Role ID
+    /**
+     * User or Role ID as a string
+     */
+    value: string;
 }
 
 export interface AttachmentArgument extends BaseArgument {
     type: typeof ApplicationCommandOptionType.ATTACHMENT;
-    value: string; // Attachment ID
+    /**
+     * Attachment ID as a string
+     */
+    value: string;
 }
 
 export type Argument =

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -217,28 +217,30 @@ export type Argument =
 // Type Mapping and Utilities
 // =============================================================================
 
+type BaseMap<T extends CommandOption> = T extends StringCommandOption
+    ? StringArgument
+    : T extends IntegerCommandOption
+      ? IntegerArgument
+      : T extends NumberCommandOption
+        ? NumberArgument
+        : T extends BooleanCommandOption
+          ? BooleanArgument
+          : T extends UserCommandOption
+            ? UserArgument
+            : T extends ChannelCommandOption
+              ? ChannelArgument
+              : T extends RoleCommandOption
+                ? RoleArgument
+                : T extends MentionableCommandOption
+                  ? MentionableArgument
+                  : T extends AttachmentCommandOption
+                    ? AttachmentArgument
+                    : Argument;
+
+type MapSingleCommandOption<T extends CommandOption> = T["required"] extends true ? BaseMap<T> : BaseMap<T> | undefined;
+
 type MapCommandOptionToArgument<T extends readonly CommandOption[]> = {
-    [K in keyof T]: T[K] extends CommandOption
-        ? T[K] extends StringCommandOption
-            ? StringArgument
-            : T[K] extends IntegerCommandOption
-              ? IntegerArgument
-              : T[K] extends NumberCommandOption
-                ? NumberArgument
-                : T[K] extends BooleanCommandOption
-                  ? BooleanArgument
-                  : T[K] extends UserCommandOption
-                    ? UserArgument
-                    : T[K] extends ChannelCommandOption
-                      ? ChannelArgument
-                      : T[K] extends RoleCommandOption
-                        ? RoleArgument
-                        : T[K] extends MentionableCommandOption
-                          ? MentionableArgument
-                          : T[K] extends AttachmentCommandOption
-                            ? AttachmentArgument
-                            : Argument
-        : never;
+    [K in keyof T]: T[K] extends CommandOption ? MapSingleCommandOption<T[K]> : never;
 };
 
 // =============================================================================

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -1,0 +1,71 @@
+export interface Argument {
+    type: ApplicationCommandOptionType;
+    name: string;
+    value: string;
+    focused: undefined;
+    options: Argument[];
+}
+
+export interface ApplicationCommand {
+    name: string;
+    description: string;
+    execute: (args: Argument[], ctx: CommandContext) => void;
+    options: ApplicationCommandOption[];
+    id?: string;
+    applicationId?: string;
+    displayName?: string;
+    displayDescription?: string;
+    untranslatedDescription?: string;
+    untranslatedName?: string;
+    inputType?: ApplicationCommandInputType;
+    type?: ApplicationCommandType;
+    __WINTRY_INTERNALS?: {
+        shouldHide?: () => boolean;
+    };
+}
+
+export interface WintryApplicationCommand extends ApplicationCommand {
+    shouldHide?: () => boolean;
+}
+
+export enum ApplicationCommandInputType {
+    BUILT_IN = 0,
+    BUILT_IN_TEXT = 1,
+    BUILT_IN_INTEGRATION = 2,
+    BOT = 3,
+    PLACEHOLDER = 4,
+}
+
+export interface ApplicationCommandOption {
+    name: string;
+    description: string;
+    required?: boolean;
+    type: ApplicationCommandOptionType;
+    displayName?: string;
+    displayDescription?: string;
+}
+
+export enum ApplicationCommandOptionType {
+    SUB_COMMAND = 1,
+    SUB_COMMAND_GROUP = 2,
+    STRING = 3,
+    INTEGER = 4,
+    BOOLEAN = 5,
+    USER = 6,
+    CHANNEL = 7,
+    ROLE = 8,
+    MENTIONABLE = 9,
+    NUMBER = 10,
+    ATTACHMENT = 11,
+}
+
+export enum ApplicationCommandType {
+    CHAT = 1,
+    USER = 2,
+    MESSAGE = 3,
+}
+
+export interface CommandContext {
+    channel: any;
+    guild: any;
+}

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -247,11 +247,11 @@ export interface ApplicationCommand<CO extends readonly CommandOption[]> {
     readonly untranslatedName?: string;
     readonly inputType?: ApplicationCommandInputType;
     readonly type?: ApplicationCommandType;
-    readonly __WINTRY_EXTRA?: WintryExtra;
+    readonly __WINTRY_EXTRA?: WintryCommandExtra;
 }
 
-interface WintryExtra {
+export interface WintryCommandExtra {
     shouldHide?: () => boolean;
 }
 
-export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryExtra;
+export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryCommandExtra;

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -236,7 +236,7 @@ type MapCommandOptionToArgument<T extends readonly CommandOption[]> = {
                           ? MentionableArgument
                           : T[K] extends AttachmentCommandOption
                             ? AttachmentArgument
-                            : never
+                            : Argument
         : never;
 };
 

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -269,7 +269,7 @@ export interface ApplicationCommand<CO extends readonly CommandOption[]> {
 
 export interface WintryCommandExtra {
     readonly __WINTRY_EXTRA?: WintryCommandExtra;
-    shouldHide?: () => boolean;
+    wt_predicate?: () => boolean;
 }
 
 export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryCommandExtra;

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -1,3 +1,4 @@
+import type { Mutable } from "@utils/types";
 import type { Channel, Guild } from "discord-types/general";
 
 // =============================================================================
@@ -262,11 +263,17 @@ export interface ApplicationCommand<CO extends readonly CommandOption[]> {
     readonly untranslatedName?: string;
     readonly inputType?: ApplicationCommandInputType;
     readonly type?: ApplicationCommandType;
-    readonly __WINTRY_EXTRA?: WintryCommandExtra;
 }
 
 export interface WintryCommandExtra {
+    readonly __WINTRY_EXTRA?: WintryCommandExtra;
     shouldHide?: () => boolean;
 }
 
 export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryCommandExtra;
+export type WintryApplicationCommandDefinition<CO extends readonly CommandOption[]> = Mutable<
+    WintryApplicationCommand<CO> & {
+        id?: never; // ID is assigned when the command is registered
+        __WINTRY_EXTRA?: never; // This is only used internally
+    }
+>;

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -269,7 +269,7 @@ export interface ApplicationCommand<CO extends readonly CommandOption[]> {
 
 export interface WintryCommandExtra {
     readonly __WINTRY_EXTRA?: WintryCommandExtra;
-    wt_predicate?: () => boolean;
+    wtPredicate?: () => boolean;
 }
 
 export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryCommandExtra;

--- a/src/api/commands/types.ts
+++ b/src/api/commands/types.ts
@@ -1,71 +1,257 @@
-export interface Argument {
-    type: ApplicationCommandOptionType;
+import type { Channel, Guild } from "discord-types/general";
+
+// =============================================================================
+// Enums and Constants
+// =============================================================================
+
+export const ApplicationCommandType = {
+    CHAT: 1,
+    USER: 2,
+    MESSAGE: 3,
+} as const;
+
+export type ApplicationCommandType = (typeof ApplicationCommandType)[keyof typeof ApplicationCommandType];
+
+export const ApplicationCommandInputType = {
+    BUILT_IN: 0,
+    BUILT_IN_TEXT: 1,
+    BUILT_IN_INTEGRATION: 2,
+    BOT: 3,
+    PLACEHOLDER: 4,
+} as const;
+
+export type ApplicationCommandInputType =
+    (typeof ApplicationCommandInputType)[keyof typeof ApplicationCommandInputType];
+
+export const ApplicationCommandOptionType = {
+    SUB_COMMAND: 1,
+    SUB_COMMAND_GROUP: 2,
+    STRING: 3,
+    INTEGER: 4,
+    BOOLEAN: 5,
+    USER: 6,
+    CHANNEL: 7,
+    ROLE: 8,
+    MENTIONABLE: 9,
+    NUMBER: 10,
+    ATTACHMENT: 11,
+} as const;
+
+export type ApplicationCommandOptionType =
+    (typeof ApplicationCommandOptionType)[keyof typeof ApplicationCommandOptionType];
+
+// =============================================================================
+// Base Interfaces
+// =============================================================================
+
+export interface BaseCommandOption {
     name: string;
-    value: string;
-    focused: undefined;
-    options: Argument[];
+    displayName?: string;
+    type: ApplicationCommandOptionType;
+    description: string;
+    displayDescription?: string;
+    required?: boolean;
+    options?: readonly CommandOption[];
+    choices?: Array<ChoicesOption>;
 }
 
-export interface ApplicationCommand {
+export interface BaseArgument {
     name: string;
     description: string;
-    execute: (args: Argument[], ctx: CommandContext) => void;
-    options: ApplicationCommandOption[];
-    id?: string;
-    applicationId?: string;
     displayName?: string;
     displayDescription?: string;
-    untranslatedDescription?: string;
-    untranslatedName?: string;
-    inputType?: ApplicationCommandInputType;
-    type?: ApplicationCommandType;
-    __WINTRY_INTERNALS?: {
-        shouldHide?: () => boolean;
-    };
+    focused?: undefined;
+    options?: Argument[];
+    required?: boolean;
 }
 
-export interface WintryApplicationCommand extends ApplicationCommand {
+export interface ChoicesOption {
+    label: string;
+    name: string;
+    displayName?: string;
+}
+
+// =============================================================================
+// Command Option Types
+// =============================================================================
+
+export interface StringCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.STRING;
+    choices?: Array<ChoicesOption & { value: string }>;
+}
+
+export interface IntegerCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.INTEGER;
+    choices?: Array<ChoicesOption & { value: number }>;
+}
+
+export interface NumberCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.NUMBER;
+    choices?: Array<ChoicesOption & { value: number }>;
+}
+
+export interface BooleanCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.BOOLEAN;
+}
+
+export interface UserCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.USER;
+}
+
+export interface ChannelCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.CHANNEL;
+}
+
+export interface RoleCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.ROLE;
+}
+
+export interface MentionableCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.MENTIONABLE;
+}
+
+export interface AttachmentCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.ATTACHMENT;
+}
+
+export interface SubCommandOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.SUB_COMMAND;
+    options?: CommandOption[];
+}
+
+export interface SubCommandGroupOption extends BaseCommandOption {
+    type: typeof ApplicationCommandOptionType.SUB_COMMAND_GROUP;
+    options?: CommandOption[];
+}
+
+export type CommandOption =
+    | StringCommandOption
+    | IntegerCommandOption
+    | NumberCommandOption
+    | BooleanCommandOption
+    | UserCommandOption
+    | ChannelCommandOption
+    | RoleCommandOption
+    | MentionableCommandOption
+    | AttachmentCommandOption
+    | SubCommandOption
+    | SubCommandGroupOption;
+
+// =============================================================================
+// Argument Types (Runtime Values)
+// =============================================================================
+
+export interface StringArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.STRING;
+    value: string;
+}
+
+export interface IntegerArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.INTEGER;
+    value: number;
+}
+
+export interface NumberArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.NUMBER;
+    value: number;
+}
+
+export interface BooleanArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.BOOLEAN;
+    value: boolean;
+}
+
+export interface UserArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.USER;
+    value: string; // User ID
+}
+
+export interface ChannelArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.CHANNEL;
+    value: string; // Channel ID
+}
+
+export interface RoleArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.ROLE;
+    value: string; // Role ID
+}
+
+export interface MentionableArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.MENTIONABLE;
+    value: string; // User or Role ID
+}
+
+export interface AttachmentArgument extends BaseArgument {
+    type: typeof ApplicationCommandOptionType.ATTACHMENT;
+    value: string; // Attachment ID
+}
+
+export type Argument =
+    | StringArgument
+    | IntegerArgument
+    | NumberArgument
+    | BooleanArgument
+    | UserArgument
+    | ChannelArgument
+    | RoleArgument
+    | MentionableArgument
+    | AttachmentArgument;
+
+// =============================================================================
+// Type Mapping and Utilities
+// =============================================================================
+
+type MapCommandOptionToArgument<T extends readonly CommandOption[]> = {
+    [K in keyof T]: T[K] extends CommandOption
+        ? T[K] extends StringCommandOption
+            ? StringArgument
+            : T[K] extends IntegerCommandOption
+              ? IntegerArgument
+              : T[K] extends NumberCommandOption
+                ? NumberArgument
+                : T[K] extends BooleanCommandOption
+                  ? BooleanArgument
+                  : T[K] extends UserCommandOption
+                    ? UserArgument
+                    : T[K] extends ChannelCommandOption
+                      ? ChannelArgument
+                      : T[K] extends RoleCommandOption
+                        ? RoleArgument
+                        : T[K] extends MentionableCommandOption
+                          ? MentionableArgument
+                          : T[K] extends AttachmentCommandOption
+                            ? AttachmentArgument
+                            : never
+        : never;
+};
+
+// =============================================================================
+// Command Context and Execution
+// =============================================================================
+
+export interface CommandContext {
+    channel: Channel;
+    guild?: Guild;
+}
+
+export interface ApplicationCommand<CO extends readonly CommandOption[]> {
+    readonly name: string;
+    readonly description: string;
+    readonly execute: (args: MapCommandOptionToArgument<CO>, ctx: CommandContext) => void;
+    readonly options: CO;
+    readonly id?: string;
+    readonly applicationId?: string;
+    readonly displayName?: string;
+    readonly displayDescription?: string;
+    readonly untranslatedDescription?: string;
+    readonly untranslatedName?: string;
+    readonly inputType?: ApplicationCommandInputType;
+    readonly type?: ApplicationCommandType;
+    readonly __WINTRY_EXTRA?: WintryExtra;
+}
+
+interface WintryExtra {
     shouldHide?: () => boolean;
 }
 
-export enum ApplicationCommandInputType {
-    BUILT_IN = 0,
-    BUILT_IN_TEXT = 1,
-    BUILT_IN_INTEGRATION = 2,
-    BOT = 3,
-    PLACEHOLDER = 4,
-}
-
-export interface ApplicationCommandOption {
-    name: string;
-    description: string;
-    required?: boolean;
-    type: ApplicationCommandOptionType;
-    displayName?: string;
-    displayDescription?: string;
-}
-
-export enum ApplicationCommandOptionType {
-    SUB_COMMAND = 1,
-    SUB_COMMAND_GROUP = 2,
-    STRING = 3,
-    INTEGER = 4,
-    BOOLEAN = 5,
-    USER = 6,
-    CHANNEL = 7,
-    ROLE = 8,
-    MENTIONABLE = 9,
-    NUMBER = 10,
-    ATTACHMENT = 11,
-}
-
-export enum ApplicationCommandType {
-    CHAT = 1,
-    USER = 2,
-    MESSAGE = 3,
-}
-
-export interface CommandContext {
-    channel: any;
-    guild: any;
-}
+export type WintryApplicationCommand<CO extends readonly CommandOption[]> = ApplicationCommand<CO> & WintryExtra;

--- a/src/components/Wintry/Settings/pages/Updater/index.tsx
+++ b/src/components/Wintry/Settings/pages/Updater/index.tsx
@@ -16,7 +16,7 @@ import { useInitConfigStore } from "@stores/useInitConfigStore";
 import { useEffect } from "react";
 
 export default function UpdaterPage() {
-    const { bunny } = getVersions();
+    const { wintry } = getVersions();
     const { isCheckingForUpdates, notifyOnNewUpdate, checkForUpdates } = useUpdaterStore();
     const { config } = useInitConfigStore();
 
@@ -43,13 +43,13 @@ export default function UpdaterPage() {
                     label={t.wintry()}
                     icon={<TableRow.Icon source={require("@assets/ic_wintry.png")} />}
                     trailing={
-                        <TableRow.TrailingText text={`${bunny.version}-${bunny.shortRevision} (${bunny.branch})`} />
+                        <TableRow.TrailingText text={`${wintry.version}-${wintry.shortRevision} (${wintry.branch})`} />
                     }
                 />
                 <TableRow
                     label={t.settings.updater.repo()}
                     icon={<TableRow.Icon source={findAssetId("img_account_sync_github_light")} />}
-                    trailing={<TableRow.TrailingText text={bunny.remote} />}
+                    trailing={<TableRow.TrailingText text={wintry.remote} />}
                 />
             </TableRowGroup>
             <View style={{ flexShrink: 1, alignSelf: "flex-end" }}>

--- a/src/components/Wintry/Settings/pages/Wintry/index.tsx
+++ b/src/components/Wintry/Settings/pages/Wintry/index.tsx
@@ -20,7 +20,7 @@ export default function WintryPage() {
     const navigation = NavigationNative.useNavigation();
     const { config, toggleSafeMode } = useInitConfigStore();
     const updateAvailable = useUpdaterStore(state => state.availableUpdate);
-    const { bunny, discord } = getVersions();
+    const { wintry, discord } = getVersions();
 
     return (
         <PageWrapper scrollable={true} containerStyle={{ paddingTop: 16, gap: 12 }}>
@@ -30,7 +30,7 @@ export default function WintryPage() {
                         title={t.wintry()}
                         tag={updateAvailable ? t.updater.update_tag() : undefined}
                         style={{ flex: 1 }}
-                        trailing={`${bunny.version}-${bunny.shortRevision}\n(${bunny.branch})`}
+                        trailing={`${wintry.version}-${wintry.shortRevision}\n(${wintry.branch})`}
                         icon={<TableRow.Icon source={require("@assets/ic_wintry.png")} />}
                         onPress={() => {
                             navigation.push("WINTRY_CUSTOM_PAGE", {

--- a/src/metro/common/libraries/Discord.ts
+++ b/src/metro/common/libraries/Discord.ts
@@ -6,3 +6,5 @@ export let constants = lookupByProps("Fonts", "Permissions").asLazy(m => (consta
 export let i18n = lookupByProps("Messages").asLazy(m => (i18n = m));
 export let tokens = lookupByProps("unsafe_rawColors", "colors").asLazy(m => (tokens = m));
 export let { useToken } = lazyDestructure(() => lookupByProps("useToken").asLazy(m => ({ useToken } = m))) as any;
+export let MessageActions = lookupByProps("sendMessage", "receiveMessage").asLazy(m => (MessageActions = m));
+export let Clyde = lookupByProps("createBotMessage").asLazy(m => (Clyde = m));

--- a/src/plugins/_api/commands/index.ts
+++ b/src/plugins/_api/commands/index.ts
@@ -64,8 +64,13 @@ export default definePlugin({
                         description: "The code to evaluate",
                         required: true,
                     },
+                    {
+                        name: "ephemeral",
+                        type: ApplicationCommandOptionType.BOOLEAN,
+                        description: "Whether to send the result as an ephemeral message",
+                    },
                 ],
-                execute([code], ctx) {
+                execute([code, ephemeral], ctx) {
                     try {
                         const res = global.eval?.(code.value);
                         const result =
@@ -75,11 +80,15 @@ export default definePlugin({
                                       depth: 0,
                                   });
 
-                        replyCommand(ctx.channel.id, { content: `\`\`\`js\n${result}\n\`\`\`` });
+                        replyCommand(ctx.channel.id, { content: `\`\`\`js\n${result}\n\`\`\`` }, ephemeral?.value);
                     } catch (error) {
-                        replyCommand(ctx.channel.id, {
-                            content: `Error: ${error instanceof Error ? error.message : String(error)}`,
-                        });
+                        replyCommand(
+                            ctx.channel.id,
+                            {
+                                content: `Error: ${error instanceof Error ? error.message : String(error)}`,
+                            },
+                            ephemeral?.value,
+                        );
                     }
                 },
             });

--- a/src/plugins/_api/commands/index.ts
+++ b/src/plugins/_api/commands/index.ts
@@ -1,0 +1,53 @@
+import { definePlugin } from "#plugin-context";
+import { patchCommands, registerCommand } from "@api/commands/index";
+import { ApplicationCommandOptionType } from "@api/commands/types";
+import { Devs } from "@data/constants";
+import { getDebugInfo } from "@debug/info";
+import { byProps } from "@metro/common/filters";
+
+export default definePlugin({
+    name: "Commands",
+    description: "Provides an API to register and manage commands.",
+    authors: [Devs.Pylix],
+
+    required: true,
+
+    patches: [
+        {
+            id: "commands",
+            target: byProps(["getBuiltInCommands"]),
+            patch(module, patcher) {
+                const unpatch = patchCommands(module);
+                patcher.attachDisposer(unpatch);
+            },
+        },
+    ],
+
+    start() {
+        registerCommand({
+            name: "debug",
+            description: "Get debug information about Wintry and the current environment",
+            options: [
+                {
+                    name: "ephemeral",
+                    type: ApplicationCommandOptionType.BOOLEAN,
+                    description: "Whether to send the debug info as an ephemeral message",
+                },
+            ],
+            execute([ephemeral], ctx) {
+                const info = getDebugInfo();
+                const content = [
+                    "**Wintry Debug Info**",
+                    `> Wintry: ${info.bunny.version} (${info.bunny.version} ${info.bunny.shortRevision})`,
+                    `> Discord: ${info.discord.version} (${info.discord.build})`,
+                    `> React: ${info.react.version} (RN ${info.reactNative.version})`,
+                    `> Hermes: ${info.hermes.buildType} (bcv${info.hermes.bytecodeVersion})`,
+                    `> System: ${info.os.name} ${info.os.version}}`.trimEnd(),
+                    `> Device: ${info.device.model} (${info.device.model})`,
+                ].join("\n");
+
+                return { content };
+            },
+        });
+    },
+});

--- a/src/plugins/_api/commands/index.ts
+++ b/src/plugins/_api/commands/index.ts
@@ -52,34 +52,36 @@ export default definePlugin({
             },
         });
 
-        registerCommand({
-            name: "eval",
-            description: "Evaluate JavaScript code",
-            options: [
-                {
-                    name: "code",
-                    type: ApplicationCommandOptionType.STRING,
-                    description: "The code to evaluate",
-                    required: true,
-                },
-            ],
-            execute([code], ctx) {
-                try {
-                    const res = global.eval?.(code.value);
-                    const result =
-                        typeof res === "string"
-                            ? res
-                            : inspect(res, {
-                                  depth: 0,
-                              });
+        // TODO: Consider exposing this to normal users, under a hidden settings and with a warning
+        if (__DEV__)
+            registerCommand({
+                name: "eval",
+                description: "Evaluate JavaScript code",
+                options: [
+                    {
+                        name: "code",
+                        type: ApplicationCommandOptionType.STRING,
+                        description: "The code to evaluate",
+                        required: true,
+                    },
+                ],
+                execute([code], ctx) {
+                    try {
+                        const res = global.eval?.(code.value);
+                        const result =
+                            typeof res === "string"
+                                ? res
+                                : inspect(res, {
+                                      depth: 0,
+                                  });
 
-                    replyCommand(ctx.channel.id, { content: `\`\`\`js\n${result}\n\`\`\`` });
-                } catch (error) {
-                    replyCommand(ctx.channel.id, {
-                        content: `Error: ${error instanceof Error ? error.message : String(error)}`,
-                    });
-                }
-            },
-        });
+                        replyCommand(ctx.channel.id, { content: `\`\`\`js\n${result}\n\`\`\`` });
+                    } catch (error) {
+                        replyCommand(ctx.channel.id, {
+                            content: `Error: ${error instanceof Error ? error.message : String(error)}`,
+                        });
+                    }
+                },
+            });
     },
 });

--- a/src/plugins/_api/commands/index.ts
+++ b/src/plugins/_api/commands/index.ts
@@ -38,15 +38,26 @@ export default definePlugin({
             ],
             execute([ephemeral], ctx) {
                 const info = getDebugInfo();
-                const content = [
-                    "**Wintry Debug Info**",
-                    `> Wintry: ${info.bunny.version} (${info.bunny.shortRevision} ${info.bunny.branch})`,
-                    `> Discord: ${info.discord.version} (${info.discord.build})`,
-                    `> React: ${info.react.version} (RN ${info.reactNative.version})`,
-                    `> Hermes Bytecode: ${info.hermes.bytecodeVersion}`,
-                    `> System: ${info.os.name} ${info.os.version}`.trimEnd(),
-                    `> Device: ${info.device.model} (${info.device.manufacturer})`,
-                ].join("\n");
+
+                const lines = [
+                    `> **Wintry** v${info.wintry.version} (${info.wintry.shortRevision}${info.wintry.branch !== "main" ? ` • ${info.wintry.branch}` : ""})`,
+                    `> **Loader** ${info.loader.name} (v${info.loader.version})`,
+                    `> **Discord** ${info.discord.version} (Build ${info.discord.build})`,
+                    `> **React** ${info.react.version} / ${info.reactNative.branch}`,
+                    `> **System** ${info.os.name} ${info.os.version}`,
+                    `> **Device** ${info.device.model}${info.device.manufacturer ? ` (${info.device.manufacturer})` : ""}`,
+                ];
+
+                const subtextItems = [
+                    `remote: ${info.wintry.remote}`,
+                    `hermes bytecode: ${info.hermes.bytecodeVersion}`,
+                    ...("sdk" in info.os ? [`sdk: ${info.os.sdk}`] : []),
+                    `brand: ${info.device.brand}`,
+                ];
+
+                lines.push(`-# ${subtextItems.join(" • ")}`);
+
+                const content = lines.join("\n");
 
                 replyCommand(ctx.channel.id, { content }, !!ephemeral?.value);
             },

--- a/src/plugins/_api/commands/index.ts
+++ b/src/plugins/_api/commands/index.ts
@@ -1,9 +1,11 @@
 import { definePlugin } from "#plugin-context";
+import { replyCommand } from "@api/commands/helpers";
 import { patchCommands, registerCommand } from "@api/commands/index";
 import { ApplicationCommandOptionType } from "@api/commands/types";
 import { Devs } from "@data/constants";
 import { getDebugInfo } from "@debug/info";
 import { byProps } from "@metro/common/filters";
+import { inspect } from "node-inspect-extracted";
 
 export default definePlugin({
     name: "Commands",
@@ -38,15 +40,45 @@ export default definePlugin({
                 const info = getDebugInfo();
                 const content = [
                     "**Wintry Debug Info**",
-                    `> Wintry: ${info.bunny.version} (${info.bunny.version} ${info.bunny.shortRevision})`,
+                    `> Wintry: ${info.bunny.version} (${info.bunny.shortRevision} ${info.bunny.branch})`,
                     `> Discord: ${info.discord.version} (${info.discord.build})`,
                     `> React: ${info.react.version} (RN ${info.reactNative.version})`,
-                    `> Hermes: ${info.hermes.buildType} (bcv${info.hermes.bytecodeVersion})`,
-                    `> System: ${info.os.name} ${info.os.version}}`.trimEnd(),
-                    `> Device: ${info.device.model} (${info.device.model})`,
+                    `> Hermes Bytecode: ${info.hermes.bytecodeVersion}`,
+                    `> System: ${info.os.name} ${info.os.version}`.trimEnd(),
+                    `> Device: ${info.device.model} (${info.device.manufacturer})`,
                 ].join("\n");
 
-                return { content };
+                replyCommand(ctx.channel.id, { content }, !!ephemeral?.value);
+            },
+        });
+
+        registerCommand({
+            name: "eval",
+            description: "Evaluate JavaScript code",
+            options: [
+                {
+                    name: "code",
+                    type: ApplicationCommandOptionType.STRING,
+                    description: "The code to evaluate",
+                    required: true,
+                },
+            ],
+            execute([code], ctx) {
+                try {
+                    const res = global.eval?.(code.value);
+                    const result =
+                        typeof res === "string"
+                            ? res
+                            : inspect(res, {
+                                  depth: 0,
+                              });
+
+                    replyCommand(ctx.channel.id, { content: `\`\`\`js\n${result}\n\`\`\`` });
+                } catch (error) {
+                    replyCommand(ctx.channel.id, {
+                        content: `Error: ${error instanceof Error ? error.message : String(error)}`,
+                    });
+                }
             },
         });
     },

--- a/src/plugins/_api/commands/index.ts
+++ b/src/plugins/_api/commands/index.ts
@@ -27,7 +27,7 @@ export default definePlugin({
 
     start() {
         registerCommand({
-            name: "debug",
+            name: "wintry-debug",
             description: "Get debug information about Wintry and the current environment",
             options: [
                 {
@@ -66,7 +66,7 @@ export default definePlugin({
         // TODO: Consider exposing this to normal users, under a hidden settings and with a warning
         if (__DEV__)
             registerCommand({
-                name: "eval",
+                name: "wintry-eval",
                 description: "Evaluate JavaScript code",
                 options: [
                     {

--- a/src/plugins/_api/commands/index.ts
+++ b/src/plugins/_api/commands/index.ts
@@ -5,6 +5,7 @@ import { ApplicationCommandOptionType } from "@api/commands/types";
 import { Devs } from "@data/constants";
 import { getDebugInfo } from "@debug/info";
 import { byProps } from "@metro/common/filters";
+import usePluginStore from "@stores/usePluginStore";
 import { inspect } from "node-inspect-extracted";
 
 export default definePlugin({
@@ -59,6 +60,31 @@ export default definePlugin({
 
                 const content = lines.join("\n");
 
+                replyCommand(ctx.channel.id, { content }, !!ephemeral?.value);
+            },
+        });
+
+        registerCommand({
+            name: "wintry-plugins",
+            description: "List all enabled plugins",
+            options: [
+                {
+                    name: "ephemeral",
+                    type: ApplicationCommandOptionType.BOOLEAN,
+                    description: "Whether to send the plugin list as an ephemeral message",
+                },
+            ],
+            execute([ephemeral], ctx) {
+                const plugins = Object.entries(usePluginStore.getState().settings)
+                    .filter(([_, settings]) => settings.enabled)
+                    .map(([id, settings]) => id);
+
+                if (plugins.length === 0) {
+                    replyCommand(ctx.channel.id, { content: "No plugins are enabled." }, !!ephemeral?.value);
+                    return;
+                }
+
+                const content = `**Enabled Plugins:**\n${plugins.join(", ")}`;
                 replyCommand(ctx.channel.id, { content }, !!ephemeral?.value);
             },
         });

--- a/src/plugins/_api/settings/index.tsx
+++ b/src/plugins/_api/settings/index.tsx
@@ -134,7 +134,7 @@ export default definePlugin({
                             const availableUpdate = useUpdaterStore(s => s.availableUpdate);
                             if (availableUpdate) return <Tag text={t.updater.update_tag()} />;
 
-                            const { version, shortRevision, branch } = getVersions().bunny;
+                            const { version, shortRevision, branch } = getVersions().wintry;
                             return `${version}-${shortRevision} (${branch})`;
                         },
                         screen: {

--- a/src/plugins/_core/error-boundary/ErrorBoundaryScreen.tsx
+++ b/src/plugins/_core/error-boundary/ErrorBoundaryScreen.tsx
@@ -43,7 +43,7 @@ export function ErrorBoundaryScreen(props: ErrorBoundaryScreenProps) {
                     <Text variant="text-md/normal">{t.error_boundary.screen.description()}</Text>
                     <Text variant="text-sm/normal" color="text-muted">
                         {debugInfo.os.name}; {debugInfo.discord.build} ({debugInfo.discord.version});{" "}
-                        {debugInfo.bunny.version} {debugInfo.bunny.shortRevision}
+                        {debugInfo.wintry.version} {debugInfo.wintry.shortRevision}
                     </Text>
                 </View>
                 <ScrollView fadingEdgeLength={64} contentContainerStyle={{ gap: 12 }}>

--- a/src/plugins/dummy/index.ts
+++ b/src/plugins/dummy/index.ts
@@ -109,7 +109,7 @@ export default definePlugin({
                 replyCommand(
                     ctx.channel.id,
                     {
-                        content: `You provided option1: ${option1.value}, option2: ${option2.value ? "true" : "false"}`,
+                        content: `You provided option1: ${option1.value}, option2: ${option2?.value}`,
                     },
                     true,
                 );

--- a/src/plugins/dummy/index.ts
+++ b/src/plugins/dummy/index.ts
@@ -1,4 +1,6 @@
 import { definePlugin, definePluginSettings } from "#plugin-context";
+import { replyCommand } from "@api/commands/helpers";
+import { ApplicationCommandOptionType } from "@api/commands/types";
 import { Devs } from "@data/constants";
 import { byProps } from "@metro/common/filters";
 
@@ -83,6 +85,45 @@ export default definePlugin({
     authors: [Devs.Pylix],
 
     isAvailable: () => __DEV__,
+
+    commands: [
+        {
+            name: "sample-command",
+            description: "A sample command that does nothing.",
+            options: [],
+            execute(args, ctx) {
+                replyCommand(ctx.channel.id, { content: "This is a sample command that does nothing." }, false);
+            },
+        },
+        {
+            // with options
+            name: "sample-command-with-options",
+            description: "A sample command with options.",
+            options: [
+                {
+                    name: "option1",
+                    type: ApplicationCommandOptionType.STRING,
+                    description: "A sample string option.",
+                    required: true,
+                },
+                {
+                    name: "option2",
+                    type: ApplicationCommandOptionType.BOOLEAN,
+                    description: "A sample boolean option.",
+                    required: false,
+                },
+            ],
+            execute([option1, option2], ctx) {
+                replyCommand(
+                    ctx.channel.id,
+                    {
+                        content: `You provided option1: ${option1.value}, option2: ${option2.value ? "true" : "false"}`,
+                    },
+                    true,
+                );
+            },
+        },
+    ],
 
     patches: [
         {

--- a/src/plugins/dummy/index.ts
+++ b/src/plugins/dummy/index.ts
@@ -3,6 +3,7 @@ import { replyCommand } from "@api/commands/helpers";
 import { ApplicationCommandOptionType } from "@api/commands/types";
 import { Devs } from "@data/constants";
 import { byProps } from "@metro/common/filters";
+import { defineCommand } from "@api/commands/helpers";
 
 const settings = definePluginSettings({
     bunnyName: {
@@ -87,16 +88,15 @@ export default definePlugin({
     isAvailable: () => __DEV__,
 
     commands: [
-        {
+        defineCommand({
             name: "sample-command",
             description: "A sample command that does nothing.",
             options: [],
             execute(args, ctx) {
                 replyCommand(ctx.channel.id, { content: "This is a sample command that does nothing." }, false);
             },
-        },
-        {
-            // with options
+        }),
+        defineCommand({
             name: "sample-command-with-options",
             description: "A sample command with options.",
             options: [
@@ -122,7 +122,7 @@ export default definePlugin({
                     true,
                 );
             },
-        },
+        }),
     ],
 
     patches: [

--- a/src/plugins/dummy/index.ts
+++ b/src/plugins/dummy/index.ts
@@ -90,14 +90,6 @@ export default definePlugin({
     commands: [
         defineCommand({
             name: "sample-command",
-            description: "A sample command that does nothing.",
-            options: [],
-            execute(args, ctx) {
-                replyCommand(ctx.channel.id, { content: "This is a sample command that does nothing." }, false);
-            },
-        }),
-        defineCommand({
-            name: "sample-command-with-options",
             description: "A sample command with options.",
             options: [
                 {
@@ -137,10 +129,4 @@ export default definePlugin({
             },
         },
     ],
-
-    start() {
-        // console.log({
-        //     settings
-        // })
-    },
 });

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -5,6 +5,7 @@ import type { Filter } from "@metro/common/filters";
 import type { ContextualPatcher } from "@patcher/contextual";
 import type { WithThis } from "@utils/types";
 import type { FluxIntercept } from "@api/flux";
+import type { WintryApplicationCommand } from "@api/commands/types";
 
 export interface PluginState {
     running: boolean;
@@ -54,7 +55,7 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
     /**
      * Define Flux event interceptors for specific event types. Allows intercepting,
      * modifying, or blocking Discord's Flux events.
-     * 
+     *
      * Each key is a Flux event type, and each value is a FluxIntercept function.
      * @example
      * ```ts
@@ -68,6 +69,9 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
      * }
      */
     readonly flux?: Record<string, FluxIntercept>;
+
+    // TODO: doc here
+    readonly commands?: Omit<WintryApplicationCommand, "id">[];
 
     /**
      * This is called once the index module is loaded and you can force lookup modules from here.

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -5,7 +5,7 @@ import type { Filter } from "@metro/common/filters";
 import type { ContextualPatcher } from "@patcher/contextual";
 import type { WithThis } from "@utils/types";
 import type { FluxIntercept } from "@api/flux";
-import type { defineCommand } from "@api/commands/helpers";
+import type { CommandOption, WintryApplicationCommandDefinition } from "@api/commands/types";
 
 export interface PluginState {
     running: boolean;
@@ -86,7 +86,7 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
      * ]
      * ```
      */
-    readonly commands?: ReturnType<typeof defineCommand>[];
+    readonly commands?: WintryApplicationCommandDefinition<CommandOption[]>[];
 
     /**
      * This is called once the index module is loaded and you can force lookup modules from here.

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -5,7 +5,7 @@ import type { Filter } from "@metro/common/filters";
 import type { ContextualPatcher } from "@patcher/contextual";
 import type { WithThis } from "@utils/types";
 import type { FluxIntercept } from "@api/flux";
-import type { WintryApplicationCommand } from "@api/commands/types";
+import type { CommandOption, WintryApplicationCommand } from "@api/commands/types";
 
 export interface PluginState {
     running: boolean;
@@ -71,7 +71,7 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
     readonly flux?: Record<string, FluxIntercept>;
 
     // TODO: doc here
-    readonly commands?: Omit<WintryApplicationCommand, "id">[];
+    readonly commands?: WintryApplicationCommand<CommandOption[]>[];
 
     /**
      * This is called once the index module is loaded and you can force lookup modules from here.

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -70,7 +70,22 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
      */
     readonly flux?: Record<string, FluxIntercept>;
 
-    // TODO: doc here
+    /**
+     * Define commands for the plugin. These commands can be used in the Discord chat.
+     * For strong typing, each command is defined using the `defineCommand` function.
+     * @example
+     * ```ts
+     * commands: [
+     *   defineCommand({
+     *     name: "hello",
+     *     description: "Says hello",
+     *     execute: (args, context) => {
+     *        // Reply to the command
+     *     },
+     *   }),
+     * ]
+     * ```
+     */
     readonly commands?: ReturnType<typeof defineCommand>[];
 
     /**

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -5,7 +5,7 @@ import type { Filter } from "@metro/common/filters";
 import type { ContextualPatcher } from "@patcher/contextual";
 import type { WithThis } from "@utils/types";
 import type { FluxIntercept } from "@api/flux";
-import type { CommandOption, WintryApplicationCommand } from "@api/commands/types";
+import type { defineCommand } from "@api/commands/helpers";
 
 export interface PluginState {
     running: boolean;
@@ -71,7 +71,7 @@ export interface WintryPluginDefinition<D extends DefinedOptions<O>, O extends O
     readonly flux?: Record<string, FluxIntercept>;
 
     // TODO: doc here
-    readonly commands?: WintryApplicationCommand<CommandOption[]>[];
+    readonly commands?: ReturnType<typeof defineCommand>[];
 
     /**
      * This is called once the index module is loaded and you can force lookup modules from here.

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,9 @@
 export type AnyRecord = Record<PropertyKey, any>;
 
+export type Mutable<T> = {
+    -readonly [P in keyof T]: T[P];
+};
+
 export type SnakeCaseToKebab<S extends string> = S extends `${infer First}_${infer Rest}`
     ? `${Lowercase<First>}-${SnakeCaseToKebab<Rest>}`
     : Lowercase<S>;


### PR DESCRIPTION
Ported from Bunny’s commands API with minor refactor and adjustments.  
Addresses #11.

## TODO
- [x] Implement plugin interface:
```ts
export default definePlugin({
    // ...
    commands: [
        {
            name: "petpet",
            execute: async (opts, cmdCtx) => {
                // ...
            },
        },
    ],
});
````

* [x] Follow Vencord’s API closely (if they add anything extra)
* [x] Double-check typings
* [x] Add more essential commands (~~/safemode,~~ /eval?)
* [x] Reconsider content of /debug (doesn't have to include everything)